### PR TITLE
fix onChange only returns integers.

### DIFF
--- a/src/RatingStar.tsx
+++ b/src/RatingStar.tsx
@@ -61,7 +61,7 @@ function RatingStar(props: IRatingStarProps) {
     setCurrentValue(nextValue);
 
     // color set
-    if (typeof onChange === "function") onChange(value);
+    if (typeof onChange === "function") onChange(nextValue);
     const color = activeColors[value - 1]
       ? activeColors[value - 1]
       : activeColor;


### PR DESCRIPTION
The React star rating component has been updated to address an issue with the onChange event. Previously, the event only returned integer values, even when users selected half-star ratings [#1](https://github.com/ziaulhoque24/react-rating-star-with-type/issues/1) This issue has been resolved, and the onChange event now correctly handles both integer and half-star values, providing a more accurate representation of user ratings.
